### PR TITLE
expose electron's accessibility tree by default

### DIFF
--- a/apps/desktop/packages/main/index.ts
+++ b/apps/desktop/packages/main/index.ts
@@ -186,6 +186,9 @@ async function createWindow() {
 }
 
 app.whenReady().then(() => {
+  // Expose chrome's accessibility tree by default
+  app.setAccessibilitySupportEnabled(true);
+
   console.log("OVERWOLF APP ID", process.env.OVERWOLF_APP_UID);
   session.defaultSession.webRequest.onBeforeSendHeaders(
     {


### PR DESCRIPTION
Electron does not expose the accessibility tree by default, causing most screen readers to not work properly.