### PR TITLE
Add missing translation

### DIFF
--- a/packages/i18n/locale/english/common.json
+++ b/packages/i18n/locale/english/common.json
@@ -37,6 +37,7 @@
   "login.acceptable_use_policy": "Acceptable Use Policy",
   "login.login": "login",
   "login.logout": "logout",
+  "login.step_back": "Back",
   "login.code_expired_message": "The code has been expired",
   "login.before_expiring": "before the code expires",
   "login.enter_code_in_browser": "Enter the specified code on the browser page to complete the authorization",


### PR DESCRIPTION
Adds missing translation for the "Back" button in the login form
<img width="577" alt="Screenshot 2024-07-30 at 15 52 16" src="https://github.com/user-attachments/assets/5ae4d1e5-3344-4cb0-b256-3ef61c59202e">
