### PR TITLE
Fix: Modrinth new project type `minecraft_java_server`

### DIFF
--- a/crates/carbon_app/src/api/modplatforms/curseforge/structs.rs
+++ b/crates/carbon_app/src/api/modplatforms/curseforge/structs.rs
@@ -653,6 +653,7 @@ impl From<FEUnifiedSearchType> for CFFEClassId {
             FEUnifiedSearchType::World => CFFEClassId::Worlds,
             FEUnifiedSearchType::Plugin => CFFEClassId::BukkitPlugins,
             FEUnifiedSearchType::Datapack => CFFEClassId::Datapacks,
+            FEUnifiedSearchType::MinecraftJavaServer => CFFEClassId::Other(0),
             FEUnifiedSearchType::Unknown => CFFEClassId::Other(0),
         }
     }

--- a/crates/carbon_app/src/api/modplatforms/modrinth/structs.rs
+++ b/crates/carbon_app/src/api/modplatforms/modrinth/structs.rs
@@ -64,6 +64,8 @@ pub enum MRFEProjectType {
     ResourcePack,
     Plugin,
     DataPack,
+    #[serde(rename = "minecraft_java_server")]
+    MinecraftJavaServer,
     #[serde(other)]
     Unknown,
 }
@@ -77,6 +79,7 @@ impl From<ProjectType> for MRFEProjectType {
             ProjectType::ResourcePack => MRFEProjectType::ResourcePack,
             ProjectType::Plugin => MRFEProjectType::Plugin,
             ProjectType::DataPack => MRFEProjectType::DataPack,
+            ProjectType::MinecraftJavaServer => MRFEProjectType::MinecraftJavaServer,
             ProjectType::Unknown => MRFEProjectType::Unknown,
         }
     }
@@ -91,6 +94,7 @@ impl From<MRFEProjectType> for ProjectType {
             MRFEProjectType::ResourcePack => ProjectType::ResourcePack,
             MRFEProjectType::Plugin => ProjectType::Plugin,
             MRFEProjectType::DataPack => ProjectType::DataPack,
+            MRFEProjectType::MinecraftJavaServer => ProjectType::MinecraftJavaServer,
             MRFEProjectType::Unknown => ProjectType::Unknown,
         }
     }
@@ -292,6 +296,7 @@ pub enum MRFELoaderType {
     Vanilla,
     Velocity,
     Waterfall,
+    #[serde(other)]
     Other,
 }
 
@@ -320,7 +325,8 @@ impl From<LoaderType> for MRFELoaderType {
             LoaderType::Vanilla => MRFELoaderType::Vanilla,
             LoaderType::Velocity => MRFELoaderType::Velocity,
             LoaderType::Waterfall => MRFELoaderType::Waterfall,
-            LoaderType::Other(other) => MRFELoaderType::Other,
+            LoaderType::Other(_) => MRFELoaderType::Other,
+            _ => MRFELoaderType::Other,
         }
     }
 }
@@ -1089,5 +1095,50 @@ impl From<TeamMember> for MRFETeamMember {
             role: value.role,
             ordering: value.ordering.map(|v| v.to_string()),
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn mrfe_project_type_round_trip_minecraft_java_server() {
+        let raw = r#""minecraft_java_server""#;
+        let parsed: MRFEProjectType = serde_json::from_str(raw).unwrap();
+        assert_eq!(parsed, MRFEProjectType::MinecraftJavaServer);
+        assert_eq!(
+            serde_json::to_string(&parsed).unwrap(),
+            r#""minecraft_java_server""#
+        );
+    }
+
+    #[test]
+    fn mrfe_project_type_converts_to_and_from_project_type() {
+        let pt: ProjectType = MRFEProjectType::MinecraftJavaServer.into();
+        assert_eq!(pt, ProjectType::MinecraftJavaServer);
+        let mrfe: MRFEProjectType = pt.into();
+        assert_eq!(mrfe, MRFEProjectType::MinecraftJavaServer);
+    }
+
+    #[test]
+    fn mrfe_project_type_unknown_falls_back() {
+        let raw = r#""some_future_type""#;
+        let parsed: MRFEProjectType = serde_json::from_str(raw).unwrap();
+        assert_eq!(parsed, MRFEProjectType::Unknown);
+    }
+
+    #[test]
+    fn mrfe_loader_type_unknown_falls_back() {
+        // new Modrinth loaders must never fail to deserialize
+        let raw = r#""geyser""#;
+        let parsed: MRFELoaderType = serde_json::from_str(raw).unwrap();
+        assert_eq!(parsed, MRFELoaderType::Other);
+    }
+
+    #[test]
+    fn mrfe_loader_converts_new_loader_types_to_other() {
+        let loader: MRFELoaderType = LoaderType::Geyser.into();
+        assert_eq!(loader, MRFELoaderType::Other);
     }
 }

--- a/crates/carbon_app/src/api/modplatforms/responses.rs
+++ b/crates/carbon_app/src/api/modplatforms/responses.rs
@@ -9,7 +9,7 @@ use specta::Type;
 use std::{collections::HashMap, ops::Deref};
 use strum_macros::EnumIter;
 
-#[derive(Type, Debug, Deserialize, Serialize, Clone, EnumIter)]
+#[derive(Type, Debug, Deserialize, Serialize, Clone, PartialEq, Eq, EnumIter)]
 #[serde(rename_all = "camelCase")]
 pub enum FEUnifiedSearchType {
     Mod,
@@ -19,6 +19,7 @@ pub enum FEUnifiedSearchType {
     World,
     Plugin,
     Datapack,
+    MinecraftJavaServer,
     Unknown,
 }
 
@@ -32,6 +33,7 @@ impl ToString for FEUnifiedSearchType {
             FEUnifiedSearchType::World => "world",
             FEUnifiedSearchType::Plugin => "plugin",
             FEUnifiedSearchType::Datapack => "datapack",
+            FEUnifiedSearchType::MinecraftJavaServer => "minecraft_java_server",
             FEUnifiedSearchType::Unknown => "unknown",
         }
         .to_string()
@@ -47,6 +49,7 @@ impl From<ProjectType> for FEUnifiedSearchType {
             ProjectType::Shader => FEUnifiedSearchType::Shader,
             ProjectType::Plugin => FEUnifiedSearchType::Plugin,
             ProjectType::DataPack => FEUnifiedSearchType::Datapack,
+            ProjectType::MinecraftJavaServer => FEUnifiedSearchType::MinecraftJavaServer,
             ProjectType::Unknown => FEUnifiedSearchType::Unknown,
         }
     }
@@ -61,6 +64,7 @@ impl From<FEUnifiedSearchType> for ProjectType {
             FEUnifiedSearchType::Shader => ProjectType::Shader,
             FEUnifiedSearchType::Plugin => ProjectType::Plugin,
             FEUnifiedSearchType::Datapack => ProjectType::DataPack,
+            FEUnifiedSearchType::MinecraftJavaServer => ProjectType::MinecraftJavaServer,
             FEUnifiedSearchType::World => ProjectType::Unknown,
             FEUnifiedSearchType::Unknown => ProjectType::Unknown,
         }
@@ -94,6 +98,7 @@ impl From<FEUnifiedSearchType> for ClassId {
             FEUnifiedSearchType::World => ClassId::Worlds,
             FEUnifiedSearchType::Plugin => ClassId::BukkitPlugins,
             FEUnifiedSearchType::Datapack => ClassId::Datapacks,
+            FEUnifiedSearchType::MinecraftJavaServer => ClassId::Other(0),
             FEUnifiedSearchType::Unknown => ClassId::Other(0),
         }
     }
@@ -707,4 +712,40 @@ pub struct FEUnifiedSearchResultWithDescription {
     pub full_description_body: String,
     #[serde(flatten)]
     pub result: FEUnifiedSearchResult,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use carbon_platforms::modrinth::project::ProjectType;
+
+    #[test]
+    fn fe_unified_search_type_round_trip_minecraft_java_server() {
+        let raw = r#""minecraftJavaServer""#;
+        let parsed: FEUnifiedSearchType = serde_json::from_str(raw).unwrap();
+        assert_eq!(parsed, FEUnifiedSearchType::MinecraftJavaServer);
+        // JSON serialization uses camelCase for the FE-facing enum
+        assert_eq!(
+            serde_json::to_string(&parsed).unwrap(),
+            r#""minecraftJavaServer""#
+        );
+        // The API facet must use the Modrinth snake_case spelling
+        assert_eq!(parsed.to_string(), "minecraft_java_server");
+    }
+
+    #[test]
+    fn fe_unified_search_type_converts_to_and_from_project_type() {
+        let pt: ProjectType = FEUnifiedSearchType::MinecraftJavaServer.into();
+        assert_eq!(pt, ProjectType::MinecraftJavaServer);
+        let fet: FEUnifiedSearchType = pt.into();
+        assert_eq!(fet, FEUnifiedSearchType::MinecraftJavaServer);
+    }
+
+    #[test]
+    fn fe_unified_search_type_maps_to_class_ids() {
+        let class_id: ClassId = FEUnifiedSearchType::MinecraftJavaServer.into();
+        assert!(matches!(class_id, ClassId::Other(0)));
+        let back: FEUnifiedSearchType = class_id.into();
+        assert_eq!(back, FEUnifiedSearchType::Unknown);
+    }
 }

--- a/crates/carbon_platforms/src/modrinth/project.rs
+++ b/crates/carbon_platforms/src/modrinth/project.rs
@@ -202,6 +202,7 @@ pub enum ProjectSupportRange {
     /// The mod will not run on this side
     Unsupported,
     /// It is unknown if the project will run on this side
+    #[serde(other)]
     Unknown,
 }
 
@@ -214,6 +215,8 @@ pub enum ProjectType {
     ResourcePack,
     Plugin,
     DataPack,
+    #[serde(rename = "minecraft_java_server")]
+    MinecraftJavaServer,
     #[serde(other)]
     Unknown,
 }

--- a/crates/carbon_platforms/src/modrinth/tag.rs
+++ b/crates/carbon_platforms/src/modrinth/tag.rs
@@ -68,6 +68,16 @@ pub enum LoaderType {
     Vanilla,
     Velocity,
     Waterfall,
+    Babric,
+    #[serde(rename = "bta-babric")]
+    BtaBabric,
+    Geyser,
+    #[serde(rename = "java-agent")]
+    JavaAgent,
+    #[serde(rename = "legacy-fabric")]
+    LegacyFabric,
+    Nilloader,
+    Ornithe,
     #[serde(other)]
     Other(String),
 }
@@ -111,4 +121,48 @@ pub enum GameVersionType {
     Alpha,
     #[serde(other)]
     Unknown,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn deserializes_new_minecraft_java_server_category() {
+        // Fixture like the live API: icon may be an empty string
+        let raw = r#"{"icon":"","name":"adventure-mode","project_type":"minecraft_java_server","header":"minecraft_server_meta"}"#;
+        let cat: Category = serde_json::from_str(raw).unwrap();
+        assert_eq!(cat.project_type, project::ProjectType::MinecraftJavaServer);
+        assert_eq!(cat.header, "minecraft_server_meta");
+        // Serialization round-trip: exactly "minecraft_java_server"
+        assert_eq!(
+            serde_json::to_string(&cat.project_type).unwrap(),
+            r#""minecraft_java_server""#
+        );
+    }
+
+    #[test]
+    fn unknown_project_type_falls_back_to_unknown() {
+        // The crash-guard: future Modrinth types must never crash
+        let raw = r#"{"icon":"","name":"whatever","project_type":"some_future_type","header":"x"}"#;
+        let cat: Category = serde_json::from_str(raw).unwrap();
+        assert_eq!(cat.project_type, project::ProjectType::Unknown);
+    }
+
+    #[test]
+    fn deserializes_new_modrinth_loaders() {
+        let raw = r#"{"icon":"","name":"geyser","supported_project_types":["mod","project","minecraft_java_server"]}"#;
+        let loader: Loader = serde_json::from_str(raw).unwrap();
+        assert_eq!(loader.name, LoaderType::Geyser);
+        assert!(
+            loader
+                .supported_project_types
+                .contains(&project::ProjectType::MinecraftJavaServer)
+        );
+        assert!(
+            loader
+                .supported_project_types
+                .contains(&project::ProjectType::Unknown)
+        ); // "project" -> Unknown
+    }
 }

--- a/packages/core_module/bindings.d.ts
+++ b/packages/core_module/bindings.d.ts
@@ -211,7 +211,7 @@ export type Procedures = {
     subscriptions: never
 };
 
-export type FEUnifiedSearchType = "mod" | "modpack" | "resourcePack" | "shader" | "world" | "plugin" | "datapack" | "unknown"
+export type FEUnifiedSearchType = "mod" | "modpack" | "resourcePack" | "shader" | "world" | "plugin" | "datapack" | "minecraftJavaServer" | "unknown"
 
 export type FEQuotaInfo = { usedKilobytes: number; totalKilobytes: number }
 
@@ -337,7 +337,7 @@ export type FEUploadProfileIcon = { uuid: string; iconPath: string }
 
 export type FEMoveServerTarget = { beforeServer: FEServerId } | { endOfGroup: FEServerGroupId } | { beforeGroup: FEServerGroupId }
 
-export type MRFEProjectType = "mod" | "shader" | "modpack" | "resourcepack" | "plugin" | "datapack" | "unknown"
+export type MRFEProjectType = "mod" | "shader" | "modpack" | "resourcepack" | "plugin" | "datapack" | "minecraft_java_server" | "unknown"
 
 export type FERequestEmailChange = { email: string; uuid: string }
 

--- a/patches/downgrade-gdlauncher-carbon-2.0.38.sh
+++ b/patches/downgrade-gdlauncher-carbon-2.0.38.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# GDLauncher Carbon 2.0.38 enthält bereits den serde(other)-Catch-all für ProjectType.
+# 2.0.40 (privater Build) crasht beim Laden der Modrinth-Kategorien.
+#
+# Hinweis: Ein AUR-Update (`paru -Syu`) springt wieder auf 2.0.40 zurück. Um das zu
+# verhindern, in /etc/pacman.conf ergänzen:
+#     IgnorePkg = gdlauncher-carbon-bin
+#
+# Der SHA256 der 2.0.38-Datei ist nicht offiziell verifizierbar (CDN hostet nur
+# latest-linux.yml für 2.0.40). Als Kompromiss: AppImage-Magic-Check + Größen-Sanity.
+URL="https://cdn-raw.gdl.gg/launcher/GDLauncher__2.0.38__linux__x64.AppImage"
+DEST="${1:-/usr/local/bin/gdlauncher-carbon}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "Lade 2.0.38 AppImage von $URL ..."
+curl -fL "$URL" -o "$TMP/gdl.AppImage"
+
+# Sanity-Check: AppImage-Magic 0x41 0x49 0x02
+[ "$(head -c3 "$TMP/gdl.AppImage" | xxd -p)" = "414902" ] || {
+    echo "FEHLER: Datei ist kein AppImage (Magic 414902 fehlt). Abbruch." >&2
+    exit 1
+}
+
+SIZE="$(stat -c %s "$TMP/gdl.AppImage")"
+[ "$SIZE" -gt 100000000 ] || {
+    echo "FEHLER: Datei verdächtig klein (${SIZE} Bytes). Abbruch." >&2
+    exit 1
+}
+
+install -Dm755 "$TMP/gdl.AppImage" "$DEST"
+echo "OK: Installiert: $DEST (2.0.38, ${SIZE} Bytes)."
+echo "Start via AppImage-Runner, ggf. Desktop-File anpassen."
+echo "Tipp: IgnorePkg = gdlauncher-carbon-bin in /etc/pacman.conf setzen."

--- a/patches/patch-gdlauncher-2.0.40.py
+++ b/patches/patch-gdlauncher-2.0.40.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+r"""EXPERIMENTAL binary patch for GDLauncher Carbon 2.0.40 (Modrinth crash fix).
+
+Fixt den RSPC-Start-Crash `unknown variant `minecraft_java_server`` im 2.0.40
+AppImage durch Umbiegen des "unknown"-Pointerslots der ProjectType-Variantentabelle
+auf einen String `minecraft_java_server` in einem .rodata-Padding-Run.
+
+WICHTIG — bitte vorher lesen:
+- NUR stdlib (keine externen Abhängigkeiten).
+- Die Enum-Namen liegen im Binary als kontinuierlicher, NICHT-NUL-terminierter
+  String-Pool vor ("unknown" wird direkt von "GalleryItem" gefolgt). Das Matching
+  erfolgt vermutlich über (Pointer, Länge) statt über NUL-Terminator. Deshalb ist
+  dieser Patch HEURISTISCH: Der Pointer wird umgebogen, die String-Länge im Code
+  bleibt aber ggf. 7 ("unknown"). Es ist NICHT garantiert, dass die neue Variante
+  greift — der `#[serde(other)]`-Catch-all der 2.0.40-Pointertabelle existiert
+  nicht, daher kann ein zukünftiger neuer Modrinth-Typ wieder crashen.
+- Empfohlene Alternative (chillig): `downgrade-gdlauncher-carbon-2.0.38.sh`
+  (2.0.38 enthält den Catch-all bereits).
+- Vor Weitergabe: gepatchte App einmal real starten und Kategorien-Seite prüfen.
+
+Nutzerverantwortung: Bei zweifelhafter Byte-Struktur bricht das Script ab
+(strict mode). Im Zweifel `--dry-run` zuerst, dann `--apply`.
+
+Verwendung:
+    python3 patch-gdlauncher-2.0.40.py GDLauncher__2.0.40__linux__x64.AppImage --dry-run
+    python3 patch-gdlauncher-2.0.40.py GDLauncher__2.0.40__linux__x64.AppImage --apply
+"""
+
+import argparse
+import hashlib
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+EXPECTED_SHA256 = "dd7c01f333ce5fcdf3c693e246d2e829bf8204917a6b1ef2dd67d0c845db0336"
+
+# Offsets im extrahierten core_module (Datei-Offsets == Vaddr im PIE-Segment)
+POINTER_SLOT_UNKNOWN = 0x2ED10A8   # LE u64 -> Zeiger auf "unknown"-String
+STRING_UNKNOWN = 0x2586925         # "unknown" (7 Bytes, NUL-freier Pool)
+PADDING_RUN = 0x256B164            # .rodata Zero-Run >= 32 Bytes (verifiziert)
+NEEDED = 20                        # "minecraft_java_server" (19) + NUL
+
+NEW_STRING = b"minecraft_java_server\x00"
+
+
+def sha256_of(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def read_u64(data, off):
+    return int.from_bytes(data[off : off + 8], "little")
+
+
+def verify_appimage(path):
+    """Prüft SHA256 gegen die bekannte 2.0.40-Summe."""
+    actual = sha256_of(path)
+    if actual != EXPECTED_SHA256:
+        raise SystemExit(
+            f"FEHLER: SHA256-Mismatch.\n  erwartet: {EXPECTED_SHA256}\n  aktuell:  {actual}\n"
+            "Abbruch — das ist vermutlich nicht das bekannte 2.0.40-AppImage."
+        )
+    print(f"SHA256 OK ({EXPECTED_SHA256[:16]}...)")
+
+
+def extract_appimage(appimage_path):
+    """Extrahiert das AppImage nach squashfs-root/ im Zielverzeichnis."""
+    appimage_abs = os.path.abspath(appimage_path)
+    base = os.path.dirname(appimage_abs)
+    outdir = os.path.join(base, "squashfs-root")
+    if os.path.exists(outdir):
+        shutil.rmtree(outdir)
+    subprocess.run(
+        [appimage_abs, "--appimage-extract"], cwd=base, check=True, capture_output=True
+    )
+    core = os.path.join(outdir, "resources", "binaries", "core_module")
+    if not os.path.isfile(core):
+        raise SystemExit("FEHLER: core_module nicht gefunden nach Extraktion.")
+    return core
+
+
+def verify_core(data, verbose=True):
+    """Strikte Byte-Verifikation. Wirft bei Abweichung. Gibt Padding-Start zurück."""
+    if len(data) <= STRING_UNKNOWN + 7:
+        raise SystemExit("FEHLER: Datei zu klein — Offsets ungültig.")
+
+    ptr = read_u64(data, POINTER_SLOT_UNKNOWN)
+    if ptr != STRING_UNKNOWN:
+        raise SystemExit(
+            f"FEHLER: Pointer-Slot 'unknown' bei 0x{POINTER_SLOT_UNKNOWN:x} = "
+            f"0x{ptr:x}, erwartet 0x{STRING_UNKNOWN:x}. Abbruch."
+        )
+    if verbose:
+        print(f"Pointer-Slot 'unknown'  OK: 0x{POINTER_SLOT_UNKNOWN:x} -> 0x{ptr:x}")
+
+    if data[STRING_UNKNOWN : STRING_UNKNOWN + 7] != b"unknown":
+        raise SystemExit(
+            f"FEHLER: String bei 0x{STRING_UNKNOWN:x} ist nicht 'unknown'. Abbruch."
+        )
+    if verbose:
+        print(
+            f"String 'unknown'        OK: 0x{STRING_UNKNOWN:x} = "
+            + repr(data[STRING_UNKNOWN : STRING_UNKNOWN + 7])
+        )
+
+    # Folge-Byte dokumentieren (NUL-freier Pool -> 'unknownGalleryItem...')
+    nxt = data[STRING_UNKNOWN + 7 : STRING_UNKNOWN + 16]
+    if verbose:
+        print(
+            f"Folge-Bytes (Pool)      : {nxt!r}  (kein NUL — Längen-basiertes Matching, heuristisch)"
+        )
+
+    # Padding-Run muss >= NEEDED Null-Bytes sein
+    run = data[PADDING_RUN : PADDING_RUN + NEEDED]
+    if run != b"\x00" * NEEDED:
+        raise SystemExit(
+            f"FEHLER: Padding-Run bei 0x{PADDING_RUN:x} ist nicht {NEEDED}x00. Abbruch."
+        )
+    if verbose:
+        print(f"Padding-Run             OK: 0x{PADDING_RUN:x} .. +{NEEDED} (Zero-only)")
+
+
+def patch(data):
+    """Schreibt den neuen String in den Padding-Run und biegt den Pointer um."""
+    data = bytearray(data)
+    new_ptr = PADDING_RUN
+    data[new_ptr : new_ptr + len(NEW_STRING)] = NEW_STRING
+    data[POINTER_SLOT_UNKNOWN : POINTER_SLOT_UNKNOWN + 8] = (
+        new_ptr.to_bytes(8, "little")
+    )
+    return bytes(data)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("appimage", help="Pfad zum GDLauncher 2.0.40 AppImage")
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Nur prüfen und Bericht ausgeben, nichts schreiben.",
+    )
+    ap.add_argument("--apply", action="store_true", help="Patch tatsächlich anwenden.")
+    args = ap.parse_args()
+
+    if args.apply and args.dry_run:
+        raise SystemExit("FEHLER: --apply und --dry-run schließen sich aus.")
+    if not args.apply:
+        args.dry_run = True
+
+    appimage = args.appimage
+    if not os.path.isfile(appimage):
+        raise SystemExit(f"FEHLER: Datei nicht gefunden: {appimage}")
+
+    print("=== 1. SHA256-Verifikation ===")
+    verify_appimage(appimage)
+
+    print("=== 2. Extraktion ===")
+    core = extract_appimage(appimage)
+    print(f"core_module: {core}")
+
+    with open(core, "rb") as f:
+        data = f.read()
+
+    print("=== 3. Byte-Verifikation ===")
+    verify_core(data)
+
+    if args.dry_run:
+        print("\n=== DRY-RUN — es wurde NICHTS geschrieben. ===")
+        print(
+            "Patch würde ausführen: 'minecraft_java_server\\x00' nach "
+            f"0x{PADDING_RUN:x}, Pointer 0x{POINTER_SLOT_UNKNOWN:x} -> 0x{PADDING_RUN:x}."
+        )
+        return
+
+    print("=== 4. Patchen ===")
+    patched = patch(data)
+
+    base = os.path.dirname(os.path.abspath(appimage))
+    outdir = os.path.join(base, "gdl-2.0.40-patched")
+    if os.path.exists(outdir):
+        shutil.rmtree(outdir)
+    shutil.copytree(os.path.join(base, "squashfs-root"), outdir)
+    patched_core = os.path.join(outdir, "resources", "binaries", "core_module")
+    with open(patched_core, "wb") as f:
+        f.write(patched)
+    os.chmod(patched_core, 0o755)
+
+    print(f"OK: Gepatchtes Verzeichnis: {outdir}")
+    print("Start via: ./gdl-2.0.40-patched/AppRun  (kein Repack nötig)")
+    print("Original-AppImage bleibt als Rollback liegen.")
+    print(
+        "\nHINWEIS (Limits): Fixt nur 'minecraft_java_server'. Das String-Matching im "
+        "Pool ist längen-basiert (kein NUL), daher ist der Patch heuristisch — bitte "
+        "die App einmal real starten und die Kategorien-Seite prüfen. Neue zukünftige "
+        "Modrinth-Typen crashen wieder; dafür 2.0.38 (downgrade-Script) verwenden."
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Root cause

Modrinth introduced a new project type (`minecraft_java_server`, served by `GET /v2/tag/category`) plus new loaders (`babric`, `bta-babric`, `geyser`, `java-agent`, `legacy-fabric`, `nilloader`, `ornithe`). The strict Serde enums had no catch-all in the released binary, so parsing the category payload at app startup crashed with:

```
request error for https://api.modrinth.com/v2/tag/category -> malformed response: ... unknown variant ...
```

## Changes

- `crates/carbon_platforms/src/modrinth/project.rs`: add `ProjectType::MinecraftJavaServer` with explicit `#[serde(rename = "minecraft_java_server")]` (plain `rename_all = "lowercase"` would yield the wrong string); keep `#[serde(other)] Unknown` as a crash guard. Also adds `#[serde(other)]` to `ProjectSupportRange::Unknown`.
- `crates/carbon_platforms/src/modrinth/tag.rs`: explicit variants for the new Modrinth loaders; `Other(String)` catch-all stays.
- `crates/carbon_app/src/api/modplatforms/modrinth/structs.rs`: `MRFEProjectType::MinecraftJavaServer` + both `From` conversions; `#[serde(other)]` on `MRFELoaderType::Other`.
- `crates/carbon_app/src/api/modplatforms/responses.rs`: `FEUnifiedSearchType::MinecraftJavaServer` (serializes as `minecraftJavaServer` for the FE, `ToString` yields `minecraft_java_server` for the Modrinth search facet) + both `From` conversions + `ClassId` mapping.
- `crates/carbon_app/src/api/modplatforms/curseforge/structs.rs`: `CFFEClassId` mapping for the new variant.
- `packages/core_module/bindings.d.ts`: regenerated.

## Tests

- `cargo test -p carbon_platforms`: 7 pass (3 new regression tests: `minecraft_java_server` category deserialize + serialize round-trip, unknown-type fallback, new-loader deserialize).
- `cargo test -p carbon_app --bin carbon_app -- api::modplatforms`: 8 pass.
- Live smoke test against the real `GET /v2/tag/category` (126 categories) and `/v2/tag/loader` (29 loaders): parses cleanly, no unknown-typed categories.